### PR TITLE
Handling multiple response in buffer due to simultaneously request

### DIFF
--- a/src/internal/ClientSocket.ts
+++ b/src/internal/ClientSocket.ts
@@ -288,9 +288,9 @@ export default class ClientSocket {
 
             this._logMessage(requestId, false, buffer.getSlice(this._offset - length, length));
 
-            var startindex = this._offset - length;
-            var endindex = this._offset;
-            var resBufferPosition = buffer._position - startindex; // From where the new buffer will start processing response
+            let startindex = this._offset - length;
+            let endindex = this._offset;
+            let resBufferPosition = buffer._position - startindex; // From where the new buffer will start processing response
 
             const single_response_buffer = MessageBuffer_1.default.from(buffer.getSlice(startindex, endindex), resBufferPosition); // Create new buffer with single response
             buffer._position = this._offset; // Make position as offset to process new response

--- a/src/internal/ClientSocket.ts
+++ b/src/internal/ClientSocket.ts
@@ -288,6 +288,14 @@ export default class ClientSocket {
 
             this._logMessage(requestId, false, buffer.getSlice(this._offset - length, length));
 
+            var startindex = this._offset - length;
+            var endindex = this._offset;
+            var resBufferPosition = buffer._position - startindex; // From where the new buffer will start processing response
+
+            const single_response_buffer = MessageBuffer_1.default.from(buffer.getSlice(startindex, endindex), resBufferPosition); // Create new buffer with single response
+            buffer._position = this._offset; // Make position as offset to process new response
+
+
             if (this._offset === buffer.length) {
                 this._buffer = null;
                 this._offset = 0;
@@ -297,10 +305,10 @@ export default class ClientSocket {
                 const request = this._requests.get(requestId);
                 this._requests.delete(requestId);
                 if (isHandshake) {
-                    await this._finalizeHandshake(buffer, request);
+                    await this._finalizeHandshake(single_response_buffer, request);
                 }
                 else {
-                    await this._finalizeResponse(buffer, request);
+                    await this._finalizeResponse(single_response_buffer, request);
                 }
             }
             else {


### PR DESCRIPTION
While using NodeJS Thin client to connect with ignite node. When we run single query to get data from ignite we were getting data but when we try to get 10 query per sec we getting below error random times.

Error: Invalid response id: 3762533188295985673
in file ignite\internal\ClientSocket.js

JMeter test for 10 request in 1 sec.
https://user-images.githubusercontent.com/83343757/116394871-0c70ed00-a841-11eb-96b8-6de5a289219e.mp4


